### PR TITLE
Fix training data and add data versioning

### DIFF
--- a/Data_cleaning/load_clean_concat.ipynb
+++ b/Data_cleaning/load_clean_concat.ipynb
@@ -158,7 +158,7 @@
     "    df['pit_number'] = int(pit_n)\n",
     "    return df\n",
     "\n",
-    "def merge_raw_cleaned(raw_dfs, clean_dfs, df_pairs: list[(str, str)] = df_pairs):\n",
+    "def merge_raw_cleaned(raw_dfs: dict[str, pd.DataFrame], clean_dfs: dict[str, pd.DataFrame], df_pairs: list[(str, str)] = df_pairs):\n",
     "    merged_dfs = []\n",
     "    for pair in df_pairs:\n",
     "        raw = raw_dfs[pair[0]]\n",
@@ -170,7 +170,7 @@
     "        else:\n",
     "            cleaned = clean_dfs[pair[1]]\n",
     "            for x in range(1,6):\n",
-    "                cleaned[f'Redox_error_flag({x})'] = (cleaned['Redox_error_flag'] == True) | (cleaned[f'Redox_Avg({x})'].isna())\n",
+    "                cleaned[f'Redox_error_flag({x})'] = ((cleaned['Redox_error_flag'] == True) & (cleaned[f'Redox_Avg({x})'].isna() == False))\n",
     "            # cleaned = cleaned.drop(['Redox_error_flag'], axis=1)\n",
     "            merged = raw.merge(\n",
     "                cleaned[['TIMESTAMP', 'Redox_error_flag(1)', 'Redox_error_flag(2)', 'Redox_error_flag(3)', 'Redox_error_flag(4)', 'Redox_error_flag(5)', 'Redox_error_flag']],\n",
@@ -237,19 +237,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_20515/1407515731.py:1: DtypeWarning: Columns (34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n",
       "/usr/lib/python3/dist-packages/pandas/core/arraylike.py:364: RuntimeWarning: divide by zero encountered in log\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n",
       "/usr/lib/python3/dist-packages/pandas/core/arraylike.py:364: RuntimeWarning: invalid value encountered in log\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n",
-      "/tmp/ipykernel_20515/1407515731.py:1: DtypeWarning: Columns (34) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (34) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n",
-      "/tmp/ipykernel_20515/1407515731.py:1: DtypeWarning: Columns (37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n",
-      "/tmp/ipykernel_20515/1407515731.py:1: DtypeWarning: Columns (7,8,9,34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (7,8,9,34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n",
-      "/tmp/ipykernel_20515/1407515731.py:1: DtypeWarning: Columns (19,20,21,30,31,34,37,38) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (19,20,21,30,31,34,37,38) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n"
      ]
     },
@@ -272,13 +272,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_20515/1407515731.py:2: DtypeWarning: Columns (37,38,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_19712/1407515731.py:2: DtypeWarning: Columns (37,38,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  clean_data = load_data(clean_data_names, data_folder)\n",
       "/usr/lib/python3/dist-packages/pandas/core/arraylike.py:364: RuntimeWarning: invalid value encountered in log\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n",
       "/usr/lib/python3/dist-packages/pandas/core/arraylike.py:364: RuntimeWarning: divide by zero encountered in log\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n",
-      "/tmp/ipykernel_20515/1407515731.py:2: DtypeWarning: Columns (47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_19712/1407515731.py:2: DtypeWarning: Columns (47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "  clean_data = load_data(clean_data_names, data_folder)\n",
+      "/tmp/ipykernel_19712/1407515731.py:2: DtypeWarning: Columns (37,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  clean_data = load_data(clean_data_names, data_folder)\n"
      ]
     },
@@ -291,14 +293,6 @@
       "VII_PIT2_2022              1                  24                     0     25\n",
       "VII_PIT3_2022              1                  12                     0     13\n",
       "VII_PIT4_2022              1                  12                     0     13\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_20515/1407515731.py:2: DtypeWarning: Columns (37,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
-      "  clean_data = load_data(clean_data_names, data_folder)\n"
      ]
     }
    ],
@@ -935,7 +929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "id": "dda2f22f",
    "metadata": {},
    "outputs": [],
@@ -971,7 +965,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "id": "9aa8400f",
    "metadata": {},
    "outputs": [
@@ -982,9 +976,9 @@
       "data for pit 4\n",
       "-----------------------\n",
       "data for sensor 1\n",
-      "number of error flags 23674\n",
+      "number of error flags 0\n",
       "number of observations total 125575\n",
-      "number of observations with at least one sigma greater than 2 and error flag 18259\n",
+      "number of observations with at least one sigma greater than 2 and error flag 0\n",
       "number of observations with at least one sigma greater than 2 104151\n"
      ]
     }
@@ -995,7 +989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "id": "1f937ae0",
    "metadata": {},
    "outputs": [
@@ -1006,9 +1000,9 @@
       "data for pit 4\n",
       "-----------------------\n",
       "data for sensor 1\n",
-      "number of error flags 23674\n",
+      "number of error flags 0\n",
       "number of observations total 125575\n",
-      "number of observations with at least one sigma greater than 2 and error flag 13532\n",
+      "number of observations with at least one sigma greater than 2 and error flag 0\n",
       "number of observations with at least one sigma greater than 2 90096\n"
      ]
     }
@@ -1027,7 +1021,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "id": "f3557eaa",
    "metadata": {},
    "outputs": [],

--- a/Data_cleaning/load_clean_concat.ipynb
+++ b/Data_cleaning/load_clean_concat.ipynb
@@ -237,19 +237,19 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_173435/1407515731.py:1: DtypeWarning: Columns (34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n",
       "/usr/lib/python3/dist-packages/pandas/core/arraylike.py:364: RuntimeWarning: divide by zero encountered in log\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n",
       "/usr/lib/python3/dist-packages/pandas/core/arraylike.py:364: RuntimeWarning: invalid value encountered in log\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n",
-      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (34) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_173435/1407515731.py:1: DtypeWarning: Columns (34) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n",
-      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_173435/1407515731.py:1: DtypeWarning: Columns (37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n",
-      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (7,8,9,34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_173435/1407515731.py:1: DtypeWarning: Columns (7,8,9,34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n",
-      "/tmp/ipykernel_19712/1407515731.py:1: DtypeWarning: Columns (19,20,21,30,31,34,37,38) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_173435/1407515731.py:1: DtypeWarning: Columns (19,20,21,30,31,34,37,38) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder)\n"
      ]
     },
@@ -272,15 +272,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_19712/1407515731.py:2: DtypeWarning: Columns (37,38,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_173435/1407515731.py:2: DtypeWarning: Columns (37,38,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  clean_data = load_data(clean_data_names, data_folder)\n",
       "/usr/lib/python3/dist-packages/pandas/core/arraylike.py:364: RuntimeWarning: invalid value encountered in log\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n",
       "/usr/lib/python3/dist-packages/pandas/core/arraylike.py:364: RuntimeWarning: divide by zero encountered in log\n",
       "  result = getattr(ufunc, method)(*inputs, **kwargs)\n",
-      "/tmp/ipykernel_19712/1407515731.py:2: DtypeWarning: Columns (47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_173435/1407515731.py:2: DtypeWarning: Columns (47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  clean_data = load_data(clean_data_names, data_folder)\n",
-      "/tmp/ipykernel_19712/1407515731.py:2: DtypeWarning: Columns (37,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_173435/1407515731.py:2: DtypeWarning: Columns (37,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  clean_data = load_data(clean_data_names, data_folder)\n"
      ]
     },
@@ -645,7 +645,8 @@
    "source": [
     "all_raw_data_df = pd.DataFrame()\n",
     "for df in merged_dfs:\n",
-    "    all_raw_data_df = pd.concat([all_raw_data_df, df], ignore_index=True)"
+    "    all_raw_data_df = pd.concat([all_raw_data_df, df], ignore_index=True)\n",
+    "all_raw_data_df['Redox_error_flag'] = all_raw_data_df['Redox_error_flag'].fillna(False)"
    ]
   },
   {

--- a/Data_versioning/README.md
+++ b/Data_versioning/README.md
@@ -1,18 +1,26 @@
-`load_and_save_data` contains code for creating consistent data to be used by across different individuals, so that every uses the exact same data for model training and testing.
-Model comparison is more accurate with versioned data.
+`load_and_save_data` contains code for creating consistent data to be used by across different individuals, so that everyone uses the exact same data for model training and testing.
+Model comparison is more precise with versioned data.
+
+## General info about the generated data
 
 Data is created for different usecases and are divided to their own folders **2022**, **2022_sensors**, **2023** and **2023_sensors**.
 
-### Usage
+We removed high Redox_avg values (>900), so that the model only focuses on finding Redox_error_flags. High values are different kind of errors and these are removed by specialist automatically by running script using a specific threshold value.
 
-Use **2022** and **2022_sensors** for model training and testing. **2023** and **2023_sensors** data is used only for testing models performance on 2023 data.
-The performance on 2023 data can't be measured statistically, but rather visually to see if the model trained on **2022** and **2022_sensors** data finds the most obvious redox_avg fluctuations.
-2023 data has no redox_error_flags, thus statistical measures are not possible for classification.
+Training and testing data are split using 70/30 rate. Training data in both 2022 folders have 57,7% of target features and testig data has 42,3% of target features.
 
-2 usecases for training was created for performance comparison. 
+Both 2022 folders include scaled and non-scaled versions, where scaled data is stored in it's own folder named 'Scaled'. For scaling data we used **MinMaxScaler**.
 
-### 2022 data
-Data includes all pits and all sensors. It is split for training and testing. Training data includes scaled and non-scaled versions.
+2 usecases for training (2022 and 2022_sensors) was created for performance comparison.
 
-### 2022_sensors data
-Data includes all pits and is split by different sensors (1-5). Additionally theses splits include split for training and testing. As in 2022 this also includes scaled and non-scaled data for training.
+## 2022 data
+Data includes **all pits** and **all sensors**.
+
+## 2022_sensors data
+Data includes **all pits** and is **split by different sensors** (1-5).
+
+## Usage
+
+Use **2022** and **2022_sensors** for model training and testing, and **2023** and **2023_sensors** only for testing models performance on 2023 data.
+
+**Note** that 2023 data doesn't have target features (Redox_error_flag/Redox_error_flag(<pit_number>), thus model performance on this data can't be measured stastically. The prediction outcomes can be only checked visually to see if the model trained on **2022** and **2022_sensors** data finds the most obvious redox_avg fluctuations.

--- a/Data_versioning/README.md
+++ b/Data_versioning/README.md
@@ -1,0 +1,18 @@
+`load_and_save_data` contains code for creating consistent data to be used by across different individuals, so that every uses the exact same data for model training and testing.
+Model comparison is more accurate with versioned data.
+
+Data is created for different usecases and are divided to their own folders **2022**, **2022_sensors**, **2023** and **2023_sensors**.
+
+### Usage
+
+Use **2022** and **2022_sensors** for model training and testing. **2023** and **2023_sensors** data is used only for testing models performance on 2023 data.
+The performance on 2023 data can't be measured statistically, but rather visually to see if the model trained on **2022** and **2022_sensors** data finds the most obvious redox_avg fluctuations.
+2023 data has no redox_error_flags, thus statistical measures are not possible for classification.
+
+2 usecases for training was created for performance comparison. 
+
+### 2022 data
+Data includes all pits and all sensors. It is split for training and testing. Training data includes scaled and non-scaled versions.
+
+### 2022_sensors data
+Data includes all pits and is split by different sensors (1-5). Additionally theses splits include split for training and testing. As in 2022 this also includes scaled and non-scaled data for training.

--- a/Data_versioning/load_and_save_data.ipynb
+++ b/Data_versioning/load_and_save_data.ipynb
@@ -10,7 +10,15 @@
     "from datetime import datetime\n",
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.preprocessing import MinMaxScaler\n",
-    "import os"
+    "import os\n",
+    "import pickle"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## General variables"
    ]
   },
   {
@@ -19,7 +27,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "training_data_folder = '../../../Data/Training'"
+    "training_data_folder = '../../../Data/Training'\n",
+    "pickle_data_path = f'{training_data_folder}/pickle_data'\n",
+    "pits = list(range(1,5))\n",
+    "redox_sensors = list(range(1,6))\n",
+    "dt_2023 = datetime(2023, 1,1, 0, 0, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Support functions"
    ]
   },
   {
@@ -29,27 +48,38 @@
    "outputs": [],
    "source": [
     "def get_y(data: pd.DataFrame, redox_sensor: int):\n",
-    "    return data.loc[:,[f'Redox_error_flag({redox_sensor})']]\n",
+    "    return data[data['TIMESTAMP'] < dt_2023].loc[:,[f'Redox_error_flag({redox_sensor})']]\n",
     "\n",
-    "def get_X(data: pd.DataFrame, redox_sensor: int):\n",
+    "def get_X(data: pd.DataFrame, redox_sensor: int, get_2023: bool = False):\n",
     "    cols = ['TIMESTAMP', f'Redox_Avg({redox_sensor})', f'Temp_T12_Avg({redox_sensor})', f'EC_Avg({redox_sensor})', f'Matric_potential_Avg({redox_sensor})',\n",
     "            'Water_level_Avg', 'Temp_ottpls_Avg', 'BatterymV_Min', f'WC{redox_sensor}', 'pit_number',\n",
     "            f'Redox_error_flag({redox_sensor})', 'Redox_error_flag', f'Redox_Avg({redox_sensor})_sigma_b_24', f'Redox_Avg({redox_sensor})_sigma_f_24',\n",
     "            f'Redox_Avg({redox_sensor})_sigma_b_12', f'Redox_Avg({redox_sensor})_sigma_f_12']\n",
-    "    return data.loc[:,cols]\n",
-    "\n",
-    "def get_train_2022_test_2023_split(data: pd.DataFrame, redox_sensor: int, random_state: int):\n",
-    "    dt_2023 = datetime(2023, 1,1, 0, 0, 0)\n",
-    "    data_2022 = data.loc[data['TIMESTAMP'] < dt_2023].sample(frac=1, random_state=random_state)\n",
-    "    data_2023 = data.loc[data['TIMESTAMP'] >= dt_2023].sample(frac=1, random_state=random_state)\n",
-    "    X_train = get_X(data_2022, redox_sensor)\n",
-    "    y_train = get_y(data_2022, redox_sensor)\n",
-    "    X_test = get_X(data_2023, redox_sensor)\n",
-    "    y_test = get_y(data_2023, redox_sensor)\n",
-    "    return (X_train, X_test, y_train, y_test)\n",
+    "    if get_2023:\n",
+    "        return data.loc[data['TIMESTAMP'] >= dt_2023].loc[:,cols]\n",
+    "    return data.loc[data['TIMESTAMP'] < dt_2023].loc[:,cols]\n",
     "\n",
     "def get_data():\n",
-    "    return pd.read_csv(f'{training_data_folder}/Raw_training_data_full.csv', parse_dates=['TIMESTAMP'])"
+    "    data = pd.read_csv(f'{training_data_folder}/Raw_training_data_full.csv', parse_dates=['TIMESTAMP'])\n",
+    "    data = data.loc[(data['Redox_Avg(1)'] <= 900) & (data['Redox_Avg(2)'] <= 900) & (data['Redox_Avg(3)'] <= 900) & (data['Redox_Avg(4)'] <= 900) & (data['Redox_Avg(5)'] <= 900)]\n",
+    "    return data\n",
+    "\n",
+    "def custom_scaler(df: pd.DataFrame, redox_sensor: int):\n",
+    "    scaled_data = df.copy()\n",
+    "    features_to_scale = [f'Redox_Avg({redox_sensor})', f'Temp_T12_Avg({redox_sensor})', f'EC_Avg({redox_sensor})', f'Matric_potential_Avg({redox_sensor})',\n",
+    "                         'Water_level_Avg', 'Temp_ottpls_Avg', 'BatterymV_Min', f'WC{redox_sensor}', f'Redox_Avg({redox_sensor})_sigma_b_24',\n",
+    "                         f'Redox_Avg({redox_sensor})_sigma_f_24', f'Redox_Avg({redox_sensor})_sigma_b_12', f'Redox_Avg({redox_sensor})_sigma_f_12']\n",
+    "\n",
+    "    scaled_data[features_to_scale] = MinMaxScaler().fit_transform(df[features_to_scale])\n",
+    "\n",
+    "    return scaled_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get full training data"
    ]
   },
   {
@@ -61,13 +91,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_21465/3851915885.py:1: DtypeWarning: Columns (40) have mixed types.Specify dtype option on import or set low_memory=False.\n",
-      "  data = get_data()\n"
+      "/tmp/ipykernel_169522/396919947.py:1: DtypeWarning: Columns (40) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "  full_data = get_data()\n"
      ]
     }
    ],
    "source": [
-    "data = get_data()"
+    "full_data = get_data()"
    ]
   },
   {
@@ -118,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Scaler"
+    "## Create directories"
    ]
   },
   {
@@ -127,22 +157,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def custom_scaler(df: pd.DataFrame, redox_sensor: int):\n",
-    "    scaled_data = df.copy()\n",
-    "    features_to_scale = [f'Redox_Avg({redox_sensor})', f'Temp_T12_Avg({redox_sensor})', f'EC_Avg({redox_sensor})', f'Matric_potential_Avg({redox_sensor})',\n",
-    "                         'Water_level_Avg', 'Temp_ottpls_Avg', 'BatterymV_Min', f'WC{redox_sensor}', f'Redox_Avg({redox_sensor})_sigma_b_24',\n",
-    "                         f'Redox_Avg({redox_sensor})_sigma_f_24', f'Redox_Avg({redox_sensor})_sigma_b_12', f'Redox_Avg({redox_sensor})_sigma_f_12']\n",
+    "def create_folder(path: str):\n",
+    "    if not os.path.exists(path):\n",
+    "        os.makedirs(path)\n",
     "\n",
-    "    scaled_data[features_to_scale] = MinMaxScaler().fit_transform(df[features_to_scale])\n",
-    "\n",
-    "    return scaled_data"
+    "create_folder(pickle_data_path)\n",
+    "for sub_folder in ['2022', '2023']:\n",
+    "    path = f'{pickle_data_path}/{sub_folder}'\n",
+    "    create_folder(path)\n",
+    "    if '2022' in sub_folder:\n",
+    "        sub_path = f'{path}/Scaled'\n",
+    "        create_folder(sub_path)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create directories"
+    "## 2022 train test split"
    ]
   },
   {
@@ -151,25 +183,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pickle_data_path = f'{training_data_folder}/pickle_data'\n",
+    "for redox_sensor in redox_sensors:\n",
+    "    X = get_X(full_data, redox_sensor)\n",
+    "    y = get_y(full_data, redox_sensor)\n",
+    "    \n",
+    "    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.30, random_state=1, stratify=y[f'Redox_error_flag({redox_sensor})'])\n",
+    "    X_train.to_pickle(f'{pickle_data_path}/2022/X_train_sensor_{redox_sensor}.pkl')\n",
+    "    X_test.to_pickle(f'{pickle_data_path}/2022/X_test_sensor_{redox_sensor}.pkl')\n",
+    "    y_train.to_pickle(f'{pickle_data_path}/2022/y_train_sensor_{redox_sensor}.pkl')\n",
+    "    y_test.to_pickle(f'{pickle_data_path}/2022/y_test_sensor_{redox_sensor}.pkl')\n",
     "\n",
-    "def create_folder(path: str):\n",
-    "    if not os.path.exists(path):\n",
-    "        os.makedirs(path)\n",
+    "    X_train_scaled = custom_scaler(X_train, redox_sensor)\n",
+    "    X_test_scaled = custom_scaler(X_test, redox_sensor)\n",
     "\n",
-    "create_folder(pickle_data_path)\n",
-    "for sub_folder in ['Mixed', 'Year']:\n",
-    "    path = f'{pickle_data_path}/{sub_folder}'\n",
-    "    create_folder(path)\n",
-    "    sub_path = f'{path}/Scaled'\n",
-    "    create_folder(sub_path)"
+    "    X_train_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_train_scaled_sensor_{redox_sensor}.pkl')\n",
+    "    X_test_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_test_scaled_sensor_{redox_sensor}.pkl')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Mixed train test split"
+    "## 2023 Testing"
    ]
   },
   {
@@ -178,46 +213,84 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i in range(1,6):\n",
-    "    X_train, X_test, y_train, y_test = train_test_split(get_X(data, i), get_y(data, i), test_size=0.30, random_state=1)\n",
-    "    X_train.to_pickle(f'{pickle_data_path}/Mixed/X_train_mixed_sensor_{i}.pkl')\n",
-    "    X_test.to_pickle(f'{pickle_data_path}/Mixed/X_test_mixed_sensor_{i}.pkl')\n",
-    "    y_train.to_pickle(f'{pickle_data_path}/Mixed/y_train_mixed_sensor_{i}.pkl')\n",
-    "    y_test.to_pickle(f'{pickle_data_path}/Mixed/y_test_mixed_sensor_{i}.pkl')\n",
-    "\n",
-    "    X_train_scaled = custom_scaler(X_train, i)\n",
-    "    X_test_scaled = custom_scaler(X_test, i)\n",
-    "\n",
-    "    X_train_scaled.to_pickle(f'{pickle_data_path}/Mixed/Scaled/X_train_scaled_mixed_sensor_{i}.pkl')\n",
-    "    X_test_scaled.to_pickle(f'{pickle_data_path}/Mixed/Scaled/X_test_scaled_mixed_sensor_{i}.pkl')"
+    "for redox_sensor in redox_sensors:\n",
+    "    X_2023 = get_X(full_data, redox_sensor, True)\n",
+    "    X.to_pickle(f'{pickle_data_path}/2023/sensor_{redox_sensor}.pkl')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2022 Training & 2023 Testing"
+    "## Redox error flag counts in training and testing data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sensor 1: \n",
+      "\tTraining_X: 2494\n",
+      "\tTraining_Y: 2494\n",
+      "\tTesting_X: 1069\n",
+      "\tTesting_Y: 1069\n",
+      "\tPercentage in testing: 0.4286287089013633\n",
+      "\n",
+      "Sensor 2: \n",
+      "\tTraining_X: 7281\n",
+      "\tTraining_Y: 7281\n",
+      "\tTesting_X: 3120\n",
+      "\tTesting_Y: 3120\n",
+      "\tPercentage in testing: 0.4285125669550886\n",
+      "\n",
+      "Sensor 3: \n",
+      "\tTraining_X: 7295\n",
+      "\tTraining_Y: 7295\n",
+      "\tTesting_X: 3126\n",
+      "\tTesting_Y: 3126\n",
+      "\tPercentage in testing: 0.4285126799177519\n",
+      "\n",
+      "Sensor 4: \n",
+      "\tTraining_X: 7295\n",
+      "\tTraining_Y: 7295\n",
+      "\tTesting_X: 3126\n",
+      "\tTesting_Y: 3126\n",
+      "\tPercentage in testing: 0.4285126799177519\n",
+      "\n",
+      "Sensor 5: \n",
+      "\tTraining_X: 7295\n",
+      "\tTraining_Y: 7295\n",
+      "\tTesting_X: 3126\n",
+      "\tTesting_Y: 3126\n",
+      "\tPercentage in testing: 0.4285126799177519\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
-    "for i in range(1,6):\n",
-    "    X_train, X_test, y_train, y_test = get_train_2022_test_2023_split(data, i, random_state=1)\n",
+    "for sensor in redox_sensors:\n",
+    "    X_train = f'{pickle_data_path}/2022/X_train_sensor_{sensor}.pkl'\n",
+    "    train_X = pickle.load(open(X_train, 'rb'))\n",
+    "    training_X = len(train_X[train_X[f'Redox_error_flag({sensor})']==True])\n",
     "\n",
-    "    X_train.to_pickle(f'{pickle_data_path}/Year/X_train_2022_sensor_{i}.pkl')\n",
-    "    X_test.to_pickle(f'{pickle_data_path}/Year/X_test_2023_sensor_{i}.pkl')\n",
-    "    y_train.to_pickle(f'{pickle_data_path}/Year/y_train_2022_sensor_{i}.pkl')\n",
-    "    y_test.to_pickle(f'{pickle_data_path}/Year/y_test_2023_sensor_{i}.pkl')\n",
+    "    y_train = f'{pickle_data_path}/2022/y_train_sensor_{sensor}.pkl'\n",
+    "    train_y = pickle.load(open(y_train, 'rb'))\n",
+    "    Training_y = len(train_y[train_y[f'Redox_error_flag({sensor})']==True])\n",
     "\n",
-    "    X_train_scaled = custom_scaler(X_train, i)\n",
-    "    X_test_scaled = custom_scaler(X_test, i)\n",
+    "    X_test = f'{pickle_data_path}/2022/X_test_sensor_{sensor}.pkl'\n",
+    "    test_X = pickle.load(open(X_test, 'rb'))\n",
+    "    testing_X = len(test_X[test_X[f'Redox_error_flag({sensor})']==True])\n",
     "\n",
-    "    X_train_scaled.to_pickle(f'{pickle_data_path}/Year/Scaled/X_train_scaled_2022_sensor_{i}.pkl')\n",
-    "    X_test_scaled.to_pickle(f'{pickle_data_path}/Year/Scaled/X_test_scaled_2023_sensor_{i}.pkl')"
+    "    y_test = f'{pickle_data_path}/2022/y_test_sensor_{sensor}.pkl'\n",
+    "    test_y = pickle.load(open(y_test, 'rb'))\n",
+    "    testing_y = len(test_y[test_y[f'Redox_error_flag({sensor})']==True])\n",
+    "\n",
+    "    print(f'Sensor {sensor}: \\n\\tTraining_X: {training_X}\\n\\tTraining_Y: {Training_y}\\n\\tTesting_X: {testing_X}\\n\\tTesting_Y: {testing_y}\\n\\tPercentage in testing: {testing_X/training_X}\\n')"
    ]
   }
  ],

--- a/Data_versioning/load_and_save_data.ipynb
+++ b/Data_versioning/load_and_save_data.ipynb
@@ -47,6 +47,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "def get_y_full(data: pd.DataFrame):\n",
+    "    return data[data['TIMESTAMP'] < dt_2023].loc[:,[f'Redox_error_flag']]\n",
+    "\n",
+    "def get_X_full(data: pd.DataFrame, get_2023: bool = False):\n",
+    "    cols_to_remove = ['log_redox(1)', 'log_redox(2)', 'log_redox(3)', 'log_redox(4)', 'log_redox(5)',\n",
+    "                      'Redox_error_flag(1)', 'Redox_error_flag(2)', 'Redox_error_flag(3)',\n",
+    "                      'Redox_error_flag(4)', 'Redox_error_flag(5)', 'Redox_error_flag_available',\n",
+    "                      'TIMESTAMP_DIFF']\n",
+    "    \n",
+    "    if get_2023:\n",
+    "        return data.loc[data['TIMESTAMP'] >= dt_2023].loc[:,~data.columns.isin(cols_to_remove)]\n",
+    "    return data.loc[data['TIMESTAMP'] < dt_2023].loc[:,~data.columns.isin(cols_to_remove)]\n",
+    "\n",
     "def get_y(data: pd.DataFrame, redox_sensor: int):\n",
     "    return data[data['TIMESTAMP'] < dt_2023].loc[:,[f'Redox_error_flag({redox_sensor})']]\n",
     "\n",
@@ -86,16 +99,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/tmp/ipykernel_169522/396919947.py:1: DtypeWarning: Columns (40) have mixed types.Specify dtype option on import or set low_memory=False.\n",
-      "  full_data = get_data()\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "full_data = get_data()"
    ]
@@ -162,7 +166,7 @@
     "        os.makedirs(path)\n",
     "\n",
     "create_folder(pickle_data_path)\n",
-    "for sub_folder in ['2022', '2023']:\n",
+    "for sub_folder in ['2022', '2023', '2022_sensors', '2023_sensors']:\n",
     "    path = f'{pickle_data_path}/{sub_folder}'\n",
     "    create_folder(path)\n",
     "    if '2022' in sub_folder:\n",
@@ -174,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2022 train test split"
+    "## 2022 specific sensors train test split"
    ]
   },
   {
@@ -187,24 +191,24 @@
     "    X = get_X(full_data, redox_sensor)\n",
     "    y = get_y(full_data, redox_sensor)\n",
     "    \n",
-    "    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.30, random_state=1, stratify=y[f'Redox_error_flag({redox_sensor})'])\n",
-    "    X_train.to_pickle(f'{pickle_data_path}/2022/X_train_sensor_{redox_sensor}.pkl')\n",
-    "    X_test.to_pickle(f'{pickle_data_path}/2022/X_test_sensor_{redox_sensor}.pkl')\n",
-    "    y_train.to_pickle(f'{pickle_data_path}/2022/y_train_sensor_{redox_sensor}.pkl')\n",
-    "    y_test.to_pickle(f'{pickle_data_path}/2022/y_test_sensor_{redox_sensor}.pkl')\n",
+    "    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.30, random_state=1, stratify=y)\n",
+    "    X_train.to_pickle(f'{pickle_data_path}/2022_sensors/X_train_sensor_{redox_sensor}.pkl')\n",
+    "    X_test.to_pickle(f'{pickle_data_path}/2022_sensors/X_test_sensor_{redox_sensor}.pkl')\n",
+    "    y_train.to_pickle(f'{pickle_data_path}/2022_sensors/y_train_sensor_{redox_sensor}.pkl')\n",
+    "    y_test.to_pickle(f'{pickle_data_path}/2022_sensors/y_test_sensor_{redox_sensor}.pkl')\n",
     "\n",
     "    X_train_scaled = custom_scaler(X_train, redox_sensor)\n",
     "    X_test_scaled = custom_scaler(X_test, redox_sensor)\n",
     "\n",
-    "    X_train_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_train_scaled_sensor_{redox_sensor}.pkl')\n",
-    "    X_test_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_test_scaled_sensor_{redox_sensor}.pkl')"
+    "    X_train_scaled.to_pickle(f'{pickle_data_path}/2022_sensors/Scaled/X_train_scaled_sensor_{redox_sensor}.pkl')\n",
+    "    X_test_scaled.to_pickle(f'{pickle_data_path}/2022_sensors/Scaled/X_test_scaled_sensor_{redox_sensor}.pkl')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2023 Testing"
+    "## 2022 Full train test split"
    ]
   },
   {
@@ -213,21 +217,67 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for redox_sensor in redox_sensors:\n",
-    "    X_2023 = get_X(full_data, redox_sensor, True)\n",
-    "    X.to_pickle(f'{pickle_data_path}/2023/sensor_{redox_sensor}.pkl')"
+    "X = get_X_full(full_data)\n",
+    "y = get_y_full(full_data)\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.30, random_state=1, stratify=y)\n",
+    "X_train.to_pickle(f'{pickle_data_path}/2022/X_train_sensor_{redox_sensor}.pkl')\n",
+    "X_test.to_pickle(f'{pickle_data_path}/2022/X_test_sensor_{redox_sensor}.pkl')\n",
+    "y_train.to_pickle(f'{pickle_data_path}/2022/y_train_sensor_{redox_sensor}.pkl')\n",
+    "y_test.to_pickle(f'{pickle_data_path}/2022/y_test_sensor_{redox_sensor}.pkl')\n",
+    "\n",
+    "X_train_scaled = custom_scaler(X_train, redox_sensor)\n",
+    "X_test_scaled = custom_scaler(X_test, redox_sensor)\n",
+    "\n",
+    "X_train_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_train_scaled_sensor_{redox_sensor}.pkl')\n",
+    "X_test_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_test_scaled_sensor_{redox_sensor}.pkl')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Redox error flag counts in training and testing data"
+    "## 2023 specific sensors Testing"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for redox_sensor in redox_sensors:\n",
+    "    X_2023 = get_X(full_data, redox_sensor, True)\n",
+    "    X.to_pickle(f'{pickle_data_path}/2023_sensors/sensor_{redox_sensor}.pkl')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2023 full Testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_2023 = get_X_full(full_data, True)\n",
+    "X.to_pickle(f'{pickle_data_path}/2023/sensor_{redox_sensor}.pkl')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Redox error flag counts in training and testing data (For sensor separated data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -274,23 +324,69 @@
    ],
    "source": [
     "for sensor in redox_sensors:\n",
-    "    X_train = f'{pickle_data_path}/2022/X_train_sensor_{sensor}.pkl'\n",
+    "    X_train = f'{pickle_data_path}/2022_sensors/X_train_sensor_{sensor}.pkl'\n",
     "    train_X = pickle.load(open(X_train, 'rb'))\n",
     "    training_X = len(train_X[train_X[f'Redox_error_flag({sensor})']==True])\n",
     "\n",
-    "    y_train = f'{pickle_data_path}/2022/y_train_sensor_{sensor}.pkl'\n",
+    "    y_train = f'{pickle_data_path}/2022_sensors/y_train_sensor_{sensor}.pkl'\n",
     "    train_y = pickle.load(open(y_train, 'rb'))\n",
     "    Training_y = len(train_y[train_y[f'Redox_error_flag({sensor})']==True])\n",
     "\n",
-    "    X_test = f'{pickle_data_path}/2022/X_test_sensor_{sensor}.pkl'\n",
+    "    X_test = f'{pickle_data_path}/2022_sensors/X_test_sensor_{sensor}.pkl'\n",
     "    test_X = pickle.load(open(X_test, 'rb'))\n",
     "    testing_X = len(test_X[test_X[f'Redox_error_flag({sensor})']==True])\n",
     "\n",
-    "    y_test = f'{pickle_data_path}/2022/y_test_sensor_{sensor}.pkl'\n",
+    "    y_test = f'{pickle_data_path}/2022_sensors/y_test_sensor_{sensor}.pkl'\n",
     "    test_y = pickle.load(open(y_test, 'rb'))\n",
     "    testing_y = len(test_y[test_y[f'Redox_error_flag({sensor})']==True])\n",
     "\n",
     "    print(f'Sensor {sensor}: \\n\\tTraining_X: {training_X}\\n\\tTraining_Y: {Training_y}\\n\\tTesting_X: {testing_X}\\n\\tTesting_Y: {testing_y}\\n\\tPercentage in testing: {testing_X/training_X}\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Redox error flag counts in training and testing data (For full data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sensor 5: \n",
+      "\tTraining_X: 7295\n",
+      "\tTraining_Y: 7295\n",
+      "\tTesting_X: 3126\n",
+      "\tTesting_Y: 3126\n",
+      "\tPercentage in testing: 0.4285126799177519\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "X_train = f'{pickle_data_path}/2022/X_train_sensor_{sensor}.pkl'\n",
+    "train_X = pickle.load(open(X_train, 'rb'))\n",
+    "training_X = len(train_X[train_X[f'Redox_error_flag']==True])\n",
+    "\n",
+    "y_train = f'{pickle_data_path}/2022/y_train_sensor_{sensor}.pkl'\n",
+    "train_y = pickle.load(open(y_train, 'rb'))\n",
+    "Training_y = len(train_y[train_y[f'Redox_error_flag']==True])\n",
+    "\n",
+    "X_test = f'{pickle_data_path}/2022/X_test_sensor_{sensor}.pkl'\n",
+    "test_X = pickle.load(open(X_test, 'rb'))\n",
+    "testing_X = len(test_X[test_X[f'Redox_error_flag']==True])\n",
+    "\n",
+    "y_test = f'{pickle_data_path}/2022/y_test_sensor_{sensor}.pkl'\n",
+    "test_y = pickle.load(open(y_test, 'rb'))\n",
+    "testing_y = len(test_y[test_y[f'Redox_error_flag']==True])\n",
+    "\n",
+    "print(f'Sensor {sensor}: \\n\\tTraining_X: {training_X}\\n\\tTraining_Y: {Training_y}\\n\\tTesting_X: {testing_X}\\n\\tTesting_Y: {testing_y}\\n\\tPercentage in testing: {testing_X/training_X}\\n')"
    ]
   }
  ],

--- a/Data_versioning/load_and_save_data.ipynb
+++ b/Data_versioning/load_and_save_data.ipynb
@@ -221,16 +221,16 @@
     "y = get_y_full(full_data)\n",
     "\n",
     "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.30, random_state=1, stratify=y)\n",
-    "X_train.to_pickle(f'{pickle_data_path}/2022/X_train_sensor_{redox_sensor}.pkl')\n",
-    "X_test.to_pickle(f'{pickle_data_path}/2022/X_test_sensor_{redox_sensor}.pkl')\n",
-    "y_train.to_pickle(f'{pickle_data_path}/2022/y_train_sensor_{redox_sensor}.pkl')\n",
-    "y_test.to_pickle(f'{pickle_data_path}/2022/y_test_sensor_{redox_sensor}.pkl')\n",
+    "X_train.to_pickle(f'{pickle_data_path}/2022/X_train.pkl')\n",
+    "X_test.to_pickle(f'{pickle_data_path}/2022/X_test.pkl')\n",
+    "y_train.to_pickle(f'{pickle_data_path}/2022/y_train.pkl')\n",
+    "y_test.to_pickle(f'{pickle_data_path}/2022/y_test.pkl')\n",
     "\n",
     "X_train_scaled = custom_scaler(X_train, redox_sensor)\n",
     "X_test_scaled = custom_scaler(X_test, redox_sensor)\n",
     "\n",
-    "X_train_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_train_scaled_sensor_{redox_sensor}.pkl')\n",
-    "X_test_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_test_scaled_sensor_{redox_sensor}.pkl')"
+    "X_train_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_train_scaled.pkl')\n",
+    "X_test_scaled.to_pickle(f'{pickle_data_path}/2022/Scaled/X_test_scaled.pkl')"
    ]
   },
   {
@@ -248,7 +248,7 @@
    "source": [
     "for redox_sensor in redox_sensors:\n",
     "    X_2023 = get_X(full_data, redox_sensor, True)\n",
-    "    X.to_pickle(f'{pickle_data_path}/2023_sensors/sensor_{redox_sensor}.pkl')"
+    "    X.to_pickle(f'{pickle_data_path}/2023_sensors/test_sensor_{redox_sensor}.pkl')"
    ]
   },
   {
@@ -265,7 +265,7 @@
    "outputs": [],
    "source": [
     "X_2023 = get_X_full(full_data, True)\n",
-    "X.to_pickle(f'{pickle_data_path}/2023/sensor_{redox_sensor}.pkl')"
+    "X.to_pickle(f'{pickle_data_path}/2023/test.pkl')"
    ]
   },
   {
@@ -370,19 +370,19 @@
     }
    ],
    "source": [
-    "X_train = f'{pickle_data_path}/2022/X_train_sensor_{sensor}.pkl'\n",
+    "X_train = f'{pickle_data_path}/2022/X_train.pkl'\n",
     "train_X = pickle.load(open(X_train, 'rb'))\n",
     "training_X = len(train_X[train_X[f'Redox_error_flag']==True])\n",
     "\n",
-    "y_train = f'{pickle_data_path}/2022/y_train_sensor_{sensor}.pkl'\n",
+    "y_train = f'{pickle_data_path}/2022/y_train.pkl'\n",
     "train_y = pickle.load(open(y_train, 'rb'))\n",
     "Training_y = len(train_y[train_y[f'Redox_error_flag']==True])\n",
     "\n",
-    "X_test = f'{pickle_data_path}/2022/X_test_sensor_{sensor}.pkl'\n",
+    "X_test = f'{pickle_data_path}/2022/X_test.pkl'\n",
     "test_X = pickle.load(open(X_test, 'rb'))\n",
     "testing_X = len(test_X[test_X[f'Redox_error_flag']==True])\n",
     "\n",
-    "y_test = f'{pickle_data_path}/2022/y_test_sensor_{sensor}.pkl'\n",
+    "y_test = f'{pickle_data_path}/2022/y_test.pkl'\n",
     "test_y = pickle.load(open(y_test, 'rb'))\n",
     "testing_y = len(test_y[test_y[f'Redox_error_flag']==True])\n",
     "\n",

--- a/Data_versioning/load_and_save_data.ipynb
+++ b/Data_versioning/load_and_save_data.ipynb
@@ -248,7 +248,7 @@
    "source": [
     "for redox_sensor in redox_sensors:\n",
     "    X_2023 = get_X(full_data, redox_sensor, True)\n",
-    "    X.to_pickle(f'{pickle_data_path}/2023_sensors/test_sensor_{redox_sensor}.pkl')"
+    "    X_2023.to_pickle(f'{pickle_data_path}/2023_sensors/test_sensor_{redox_sensor}.pkl')"
    ]
   },
   {
@@ -265,7 +265,7 @@
    "outputs": [],
    "source": [
     "X_2023 = get_X_full(full_data, True)\n",
-    "X.to_pickle(f'{pickle_data_path}/2023/test.pkl')"
+    "X_2023.to_pickle(f'{pickle_data_path}/2023/test.pkl')"
    ]
   },
   {

--- a/Data_versioning/load_and_save_data.ipynb
+++ b/Data_versioning/load_and_save_data.ipynb
@@ -1,0 +1,245 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from datetime import datetime\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data_folder = '../../../Data/Training'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_y(data: pd.DataFrame, redox_sensor: int):\n",
+    "    return data.loc[:,[f'Redox_error_flag({redox_sensor})']]\n",
+    "\n",
+    "def get_X(data: pd.DataFrame, redox_sensor: int):\n",
+    "    cols = ['TIMESTAMP', f'Redox_Avg({redox_sensor})', f'Temp_T12_Avg({redox_sensor})', f'EC_Avg({redox_sensor})', f'Matric_potential_Avg({redox_sensor})',\n",
+    "            'Water_level_Avg', 'Temp_ottpls_Avg', 'BatterymV_Min', f'WC{redox_sensor}', 'pit_number',\n",
+    "            f'Redox_error_flag({redox_sensor})', 'Redox_error_flag', f'Redox_Avg({redox_sensor})_sigma_b_24', f'Redox_Avg({redox_sensor})_sigma_f_24',\n",
+    "            f'Redox_Avg({redox_sensor})_sigma_b_12', f'Redox_Avg({redox_sensor})_sigma_f_12']\n",
+    "    return data.loc[:,cols]\n",
+    "\n",
+    "def get_train_2022_test_2023_split(data: pd.DataFrame, redox_sensor: int, random_state: int):\n",
+    "    dt_2023 = datetime(2023, 1,1, 0, 0, 0)\n",
+    "    data_2022 = data.loc[data['TIMESTAMP'] < dt_2023].sample(frac=1, random_state=random_state)\n",
+    "    data_2023 = data.loc[data['TIMESTAMP'] >= dt_2023].sample(frac=1, random_state=random_state)\n",
+    "    X_train = get_X(data_2022, redox_sensor)\n",
+    "    y_train = get_y(data_2022, redox_sensor)\n",
+    "    X_test = get_X(data_2023, redox_sensor)\n",
+    "    y_test = get_y(data_2023, redox_sensor)\n",
+    "    return (X_train, X_test, y_train, y_test)\n",
+    "\n",
+    "def get_data():\n",
+    "    return pd.read_csv(f'{training_data_folder}/Raw_training_data_full.csv', parse_dates=['TIMESTAMP'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_21465/3851915885.py:1: DtypeWarning: Columns (40) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "  data = get_data()\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = get_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Removed columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Redox_Avg({num != redox_sensor})',\n",
+       " 'Temp_T12_Avg({num != redox_sensor})',\n",
+       " 'EC_Avg({num != redox_sensor})',\n",
+       " 'Matric_potential_Avg({num != redox_sensor})',\n",
+       " 'WC{num != redox_sensor}',\n",
+       " 'log_redox(all)',\n",
+       " 'Redox_error_flag({num != redox_sensor})',\n",
+       " 'Redox_error_flag_available',\n",
+       " 'TIMESTAMP_DIFF',\n",
+       " 'Redox_Avg({num != redox_sensor})_sigma_b_24',\n",
+       " 'Redox_Avg({num != redox_sensor})_sigma_f_24',\n",
+       " 'Redox_Avg({num != redox_sensor})_sigma_b_12',\n",
+       " 'Redox_Avg({num != redox_sensor})_sigma_f_12']"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "removed_cols = ['Redox_Avg({num != redox_sensor})', 'Temp_T12_Avg({num != redox_sensor})', 'EC_Avg({num != redox_sensor})',\n",
+    "                    'Matric_potential_Avg({num != redox_sensor})', 'WC{num != redox_sensor}', 'log_redox(all)',\n",
+    "                    'Redox_error_flag({num != redox_sensor})', 'Redox_error_flag_available', 'TIMESTAMP_DIFF',\n",
+    "                    'Redox_Avg({num != redox_sensor})_sigma_b_24', 'Redox_Avg({num != redox_sensor})_sigma_f_24',\n",
+    "                    'Redox_Avg({num != redox_sensor})_sigma_b_12', 'Redox_Avg({num != redox_sensor})_sigma_f_12']\n",
+    "removed_cols"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scaler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def custom_scaler(df: pd.DataFrame, redox_sensor: int):\n",
+    "    scaled_data = df.copy()\n",
+    "    features_to_scale = [f'Redox_Avg({redox_sensor})', f'Temp_T12_Avg({redox_sensor})', f'EC_Avg({redox_sensor})', f'Matric_potential_Avg({redox_sensor})',\n",
+    "                         'Water_level_Avg', 'Temp_ottpls_Avg', 'BatterymV_Min', f'WC{redox_sensor}', f'Redox_Avg({redox_sensor})_sigma_b_24',\n",
+    "                         f'Redox_Avg({redox_sensor})_sigma_f_24', f'Redox_Avg({redox_sensor})_sigma_b_12', f'Redox_Avg({redox_sensor})_sigma_f_12']\n",
+    "\n",
+    "    scaled_data[features_to_scale] = MinMaxScaler().fit_transform(df[features_to_scale])\n",
+    "\n",
+    "    return scaled_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create directories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pickle_data_path = f'{training_data_folder}/pickle_data'\n",
+    "\n",
+    "def create_folder(path: str):\n",
+    "    if not os.path.exists(path):\n",
+    "        os.makedirs(path)\n",
+    "\n",
+    "create_folder(pickle_data_path)\n",
+    "for sub_folder in ['Mixed', 'Year']:\n",
+    "    path = f'{pickle_data_path}/{sub_folder}'\n",
+    "    create_folder(path)\n",
+    "    sub_path = f'{path}/Scaled'\n",
+    "    create_folder(sub_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mixed train test split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(1,6):\n",
+    "    X_train, X_test, y_train, y_test = train_test_split(get_X(data, i), get_y(data, i), test_size=0.30, random_state=1)\n",
+    "    X_train.to_pickle(f'{pickle_data_path}/Mixed/X_train_mixed_sensor_{i}.pkl')\n",
+    "    X_test.to_pickle(f'{pickle_data_path}/Mixed/X_test_mixed_sensor_{i}.pkl')\n",
+    "    y_train.to_pickle(f'{pickle_data_path}/Mixed/y_train_mixed_sensor_{i}.pkl')\n",
+    "    y_test.to_pickle(f'{pickle_data_path}/Mixed/y_test_mixed_sensor_{i}.pkl')\n",
+    "\n",
+    "    X_train_scaled = custom_scaler(X_train, i)\n",
+    "    X_test_scaled = custom_scaler(X_test, i)\n",
+    "\n",
+    "    X_train_scaled.to_pickle(f'{pickle_data_path}/Mixed/Scaled/X_train_scaled_mixed_sensor_{i}.pkl')\n",
+    "    X_test_scaled.to_pickle(f'{pickle_data_path}/Mixed/Scaled/X_test_scaled_mixed_sensor_{i}.pkl')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2022 Training & 2023 Testing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(1,6):\n",
+    "    X_train, X_test, y_train, y_test = get_train_2022_test_2023_split(data, i, random_state=1)\n",
+    "\n",
+    "    X_train.to_pickle(f'{pickle_data_path}/Year/X_train_2022_sensor_{i}.pkl')\n",
+    "    X_test.to_pickle(f'{pickle_data_path}/Year/X_test_2023_sensor_{i}.pkl')\n",
+    "    y_train.to_pickle(f'{pickle_data_path}/Year/y_train_2022_sensor_{i}.pkl')\n",
+    "    y_test.to_pickle(f'{pickle_data_path}/Year/y_test_2023_sensor_{i}.pkl')\n",
+    "\n",
+    "    X_train_scaled = custom_scaler(X_train, i)\n",
+    "    X_test_scaled = custom_scaler(X_test, i)\n",
+    "\n",
+    "    X_train_scaled.to_pickle(f'{pickle_data_path}/Year/Scaled/X_train_scaled_2022_sensor_{i}.pkl')\n",
+    "    X_test_scaled.to_pickle(f'{pickle_data_path}/Year/Scaled/X_test_scaled_2023_sensor_{i}.pkl')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Reports/get_report.ipynb
+++ b/Reports/get_report.ipynb
@@ -21,7 +21,7 @@
    "id": "11750d9c",
    "metadata": {},
    "source": [
-    "### General variables"
+    "## General variables"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "id": "19558cda",
    "metadata": {},
    "source": [
-    "### Helper functions"
+    "## Helper functions"
    ]
   },
   {
@@ -124,7 +124,7 @@
    "id": "9ce5bcde",
    "metadata": {},
    "source": [
-    "### Load data and get findings"
+    "## Load data and get findings"
    ]
   },
   {
@@ -137,15 +137,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_86178/3030246735.py:2: DtypeWarning: Columns (34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_169570/3030246735.py:2: DtypeWarning: Columns (34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder, findings_dict)\n",
-      "/tmp/ipykernel_86178/3030246735.py:2: DtypeWarning: Columns (34) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_169570/3030246735.py:2: DtypeWarning: Columns (34) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder, findings_dict)\n",
-      "/tmp/ipykernel_86178/3030246735.py:2: DtypeWarning: Columns (37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_169570/3030246735.py:2: DtypeWarning: Columns (37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder, findings_dict)\n",
-      "/tmp/ipykernel_86178/3030246735.py:2: DtypeWarning: Columns (7,8,9,34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_169570/3030246735.py:2: DtypeWarning: Columns (7,8,9,34,37) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder, findings_dict)\n",
-      "/tmp/ipykernel_86178/3030246735.py:2: DtypeWarning: Columns (19,20,21,30,31,34,37,38) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_169570/3030246735.py:2: DtypeWarning: Columns (19,20,21,30,31,34,37,38) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  raw_data = load_data(raw_data_names, data_folder, findings_dict)\n"
      ]
     },
@@ -168,9 +168,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_86178/3030246735.py:3: DtypeWarning: Columns (37,38,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_169570/3030246735.py:3: DtypeWarning: Columns (37,38,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  clean_data = load_data(clean_data_names, data_folder, findings_dict)\n",
-      "/tmp/ipykernel_86178/3030246735.py:3: DtypeWarning: Columns (47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_169570/3030246735.py:3: DtypeWarning: Columns (47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  clean_data = load_data(clean_data_names, data_folder, findings_dict)\n"
      ]
     },
@@ -181,7 +181,7 @@
       "               Date_no_match  Duplicates   NaNs  Total  row_cnt\n",
       "VII_PIT1_2022              1         192  76117  76310    76117\n",
       "VII_PIT2_2022              1          24  72388  72413    75949\n",
-      "VII_PIT3_2022              1          12  19600  19613    27096\n",
+      "VII_PIT3_2022              1          12  27095  27108    27096\n",
       "VII_PIT4_2022              1          12  25225  25238    25225\n"
      ]
     },
@@ -189,7 +189,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_86178/3030246735.py:3: DtypeWarning: Columns (38) have mixed types.Specify dtype option on import or set low_memory=False.\n",
+      "/tmp/ipykernel_169570/3030246735.py:3: DtypeWarning: Columns (37,47) have mixed types.Specify dtype option on import or set low_memory=False.\n",
       "  clean_data = load_data(clean_data_names, data_folder, findings_dict)\n"
      ]
     }
@@ -205,7 +205,7 @@
    "id": "38f22cbc",
    "metadata": {},
    "source": [
-    "### Save findings as a csv\n",
+    "## Save findings as a csv\n",
     "\n",
     "Each column values are row index in the original csv"
    ]
@@ -226,7 +226,7 @@
    "id": "bd17ef9f",
    "metadata": {},
    "source": [
-    "### Check where redox values differ in raw and cleaned data and save as csv\n",
+    "## Check where redox values differ in raw and cleaned data and save as csv\n",
     "\n",
     "Csv contains timestamp and redox values from both raw and cleaned data"
    ]
@@ -289,7 +289,7 @@
    "id": "63879d78",
    "metadata": {},
    "source": [
-    "### See if raw data has missing values on timestamps where clean data has redox error flag"
+    "## See if raw data has missing values on timestamps where clean data has redox error flag"
    ]
   },
   {
@@ -394,7 +394,92 @@
     "\n",
     "Pit2 there are only 2 rows which are to be removed from the training data so no major impact on that.\n",
     "\n",
-    "Pit3 missing values on redox_error_flag = true are from column \"shfp_wrnng_flg\". These have no impact on the removed values in training data since that column will be removed anyways. This column has no impact on redox_avg based on experts opinions."
+    "Pit3 missing values on redox_error_flag = true are from column \"shfp_wrnng_flg\". These have no impact on the removed values in training data since that column will be removed and the redox_error_flag will be included in the training data. This column has no impact on redox_avg based on experts opinions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2b67830",
+   "metadata": {},
+   "source": [
+    "## Redox_error_flag count per pit per sensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6201a2b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "VII_PIT1_2022\n",
+      "\tSensor 1\n",
+      "\t\tRedox_error_flag count: 0\n",
+      "\tSensor 2\n",
+      "\t\tRedox_error_flag count: 6211\n",
+      "\tSensor 3\n",
+      "\t\tRedox_error_flag count: 6137\n",
+      "\tSensor 4\n",
+      "\t\tRedox_error_flag count: 6177\n",
+      "\tSensor 5\n",
+      "\t\tRedox_error_flag count: 6189\n",
+      "VII_PIT2_2022\n",
+      "\tSensor 1\n",
+      "\t\tRedox_error_flag count: 3561\n",
+      "\tSensor 2\n",
+      "\t\tRedox_error_flag count: 6548\n",
+      "\tSensor 3\n",
+      "\t\tRedox_error_flag count: 7713\n",
+      "\tSensor 4\n",
+      "\t\tRedox_error_flag count: 7713\n",
+      "\tSensor 5\n",
+      "\t\tRedox_error_flag count: 7737\n",
+      "VII_PIT3_2022\n",
+      "\tSensor 1\n",
+      "\t\tRedox_error_flag count: 2\n",
+      "\tSensor 2\n",
+      "\t\tRedox_error_flag count: 2\n",
+      "\tSensor 3\n",
+      "\t\tRedox_error_flag count: 2\n",
+      "\tSensor 4\n",
+      "\t\tRedox_error_flag count: 2\n",
+      "\tSensor 5\n",
+      "\t\tRedox_error_flag count: 2\n",
+      "VII_PIT4_2022\n",
+      "\tSensor 1\n",
+      "\t\tRedox_error_flag count: 0\n",
+      "\tSensor 2\n",
+      "\t\tRedox_error_flag count: 0\n",
+      "\tSensor 3\n",
+      "\t\tRedox_error_flag count: 1\n",
+      "\tSensor 4\n",
+      "\t\tRedox_error_flag count: 1\n",
+      "\tSensor 5\n",
+      "\t\tRedox_error_flag count: 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "for (raw_name, raw_df), (clean_name, clean_df) in zip(raw_data.items(), clean_data.items()):\n",
+    "    if '2022' in raw_name:\n",
+    "        print(clean_name)\n",
+    "        for sensor in range(1,6):\n",
+    "            clean = clean_df.loc[clean_df[f'Redox_Avg({sensor})'] <= 900]\n",
+    "            redox_errors_for_sensor = len(clean.loc[(clean['Redox_error_flag'] == True) & (clean[f'Redox_Avg({sensor})'].isna() == False)])\n",
+    "            print(f'\\tSensor {sensor}\\n\\t\\tRedox_error_flag count: {redox_errors_for_sensor}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a7d64da",
+   "metadata": {},
+   "source": [
+    "### Evaluation\n",
+    "\n",
+    "It seems that we can't train separate models per pit. There are not enought data points for the target feature in pit3, pit4 and in pit1 sensor 1"
    ]
   },
   {
@@ -402,7 +487,7 @@
    "id": "c86cd7ca",
    "metadata": {},
    "source": [
-    "### Correlation of redox_avg and other features"
+    "## Correlation of redox_avg and other features"
    ]
   },
   {


### PR DESCRIPTION
Changes:

Raw training data:
Redox_error_flag(sensor_number) has now only redox error flag values for that sensor. Previously had also abnormal values.
Redox_error_flag NaN values have now False value instead

Added code for data versioning (pickled data):
Data is versioned so different models can be more accurately compared.
The data is separated to:
2022:
  This includes all pits and all sensors. Data is divided into training and testing.
2022_sensors
  This includes all pits combined but sensor related data is separated as its own for training and testing.
2023
  This includes all pits and all sensors of 2023 data. Main use for this file is to test the predictions output for 2023 data from the 2022 trained model
2023_sensors
  This includes all pits combined but sensor related data is separated for testing the predictions output for 2023 sensors data from the 2022_sensor trained model

Added report about pit and sensor separated data. Conclusion is that data can't be split by pits since there are not enough redox_error_values in some pits or sensors.